### PR TITLE
Don't count todo passed tests twice

### DIFF
--- a/lib/TAP/Formatter/HTML.pm
+++ b/lib/TAP/Formatter/HTML.pm
@@ -384,9 +384,8 @@ sub prepare_report {
     }
 
     # do some other handy calcs:
-    $r->{actual_passed} = $r->{passed} + $r->{todo_passed};
     if ($r->{total}) {
-	$r->{percent_passed} = sprintf('%.1f', $r->{actual_passed} / $r->{total} * 100);
+	$r->{percent_passed} = sprintf('%.1f', $r->{passed} / $r->{total} * 100);
     } else {
 	$r->{percent_passed} = 0;
     }


### PR DESCRIPTION
Originally the todo_passed count was added to the passed count in an effort to get the expected >100% success ratio if there were more tests run than advertised, i.e. unplanned tests. However this just leads to TODO passed test being counted twice.

The reason that unplanned tests do not lead to a >100% success ratio is, on one hand that the count total includes those tests and on the other hand that unplanned tests are automatically evaluated as !is_ok by TAP::Parser::Result. Therefore unplanned tests will not as initially expected generate a success ratio >100%, but instead lead to a lower success ratio.

Since achieving the former would require changes in TAP::Parser::Result and TAP::Parser::Aggregate, this commit simply reverts the incorrect fix.